### PR TITLE
Fix NoMethodError when no custom Puma config is present in newrelic.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.bundle/
+/.idea/
 /.yardoc
 /_yardoc/
 /coverage/

--- a/lib/puma/new_relic/sampler.rb
+++ b/lib/puma/new_relic/sampler.rb
@@ -2,7 +2,7 @@ module Puma
   module NewRelic
     class Sampler
       def initialize(launcher)
-        config          = ::NewRelic::Agent.config[:puma]
+        config          = ::NewRelic::Agent.config[:puma] || {}
         @launcher       = launcher
         @sample_rate    = config.fetch("sample_rate", 15)
         @keys           = config.fetch("keys", %w(backlog running pool_capacity max_threads)).map(&:to_sym)


### PR DESCRIPTION
Fix possible error when no custom config is present in `newrelic.yml`:
```
/bundle/ruby/2.5.0/gems/puma-newrelic-0.1.3/lib/puma/new_relic/sampler.rb:7:in `initialize': undefined method `fetch' for nil:NilClass (NoMethodError)
	from /bundle/ruby/2.5.0/gems/puma-newrelic-0.1.3/lib/puma/plugin/new_relic_stats.rb:5:in `new'
	from /bundle/ruby/2.5.0/gems/puma-newrelic-0.1.3/lib/puma/plugin/new_relic_stats.rb:5:in `start'
```
